### PR TITLE
Update TOKEN_URLs

### DIFF
--- a/src/main/java/edu/cornell/mannlib/orcidclient/context/OrcidAPIConfig.java
+++ b/src/main/java/edu/cornell/mannlib/orcidclient/context/OrcidAPIConfig.java
@@ -31,12 +31,12 @@ public class OrcidAPIConfig {
             this.PUBLIC_URL = "https://pub.sandbox.orcid.org/" + version.toString() + "/";
             this.MEMBER_URL = "https://api.sandbox.orcid.org/" + version.toString() + "/";
             this.OAUTH_URL = "https://sandbox.orcid.org/oauth/authorize";
-            this.TOKEN_URL = "https://api.sandbox.orcid.org/oauth/token";
+            this.TOKEN_URL = "https://sandbox.orcid.org/oauth/token";
         } else {
             this.PUBLIC_URL = "https://pub.orcid.org/" + version.toString() + "/";
             this.MEMBER_URL = "https://api.orcid.org/" + version.toString() + "/";
             this.OAUTH_URL = "https://orcid.org/oauth/authorize";
-            this.TOKEN_URL = "https://api.orcid.org/oauth/token";
+            this.TOKEN_URL = "https://orcid.org/oauth/token";
         }
     }
 }


### PR DESCRIPTION
Updates TOKEN_URL for OAuth to the recommended URLs in the [ORCID documentation](https://members.orcid.org/api/oauth/3legged-oauth). 

There should be no discernible change for member API users, but this will allow users of the public API to complete the OAuth process and confirm an ORCID in VIVO.

Relevant ORCID Trello conversation: https://trello.com/c/1cgOG7Mt/2011-allow-token-exchange-at-https-orcid-org-oauth-token
And subsequent merged pull request: https://github.com/ORCID/ORCID-Source/pull/2069

Tested against develop VIVO/Vitro branches using public and sandbox v2.0 ORCID APIs.