### PR TITLE
Append https instead of http to ORCID to match style guidelines

### DIFF
--- a/src/main/java/edu/cornell/mannlib/orcidclient/actions/version_2_0/Util.java
+++ b/src/main/java/edu/cornell/mannlib/orcidclient/actions/version_2_0/Util.java
@@ -92,7 +92,7 @@ public class Util {
                 OrcidId oid = new OrcidId();
 
                 oid.setPath(om.getName().getPath());
-                oid.setUri("http://orcid.org/" + om.getName().getPath());
+                oid.setUri("https://orcid.org/" + om.getName().getPath());
                 profile.setOrcidIdentifier(oid);
             }
 


### PR DESCRIPTION
Partially addresses [VIVO-1435](https://jira.duraspace.org/browse/VIVO-1435). 

Simply changes the ORCID returned by the client to using https instead of http as recommended by the latest [ORCID style guidelines](https://orcid.org/trademark-and-id-display-guidelines). 

Tested working against develop VIVO/Vitro branches.