### PR TITLE
Migrate from OSSRH to Central Publisher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,12 +152,10 @@
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -263,8 +261,8 @@
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.7</version>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -279,12 +277,15 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <name>Sonatype Central Snapshots</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
**[4082](https://github.com/vivo-project/VIVO/issues/4082)**

# What does this pull request do?
Fixing the issue with deploying artefacts into the Maven central repository. It is done via Central Publisher Portal. So far it works over OSSRH which support will be discontinued (see [here](https://central.sonatype.org/publish/publish-maven/)). 

# What's new?
Sonatype plugin was replaced as well as configuration for publisher portal. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @VIVO-project/vivo-committers

# Reviewers' expertise
**Please add any new expertise in the list which might be needed for reviewing your PR or remove any of the listed if it is not needed.**

Candidates for reviewing this PR should have some of the following expertises:
1. Maven
